### PR TITLE
Warehouse endpoint v2

### DIFF
--- a/tests/TestClientResource.py
+++ b/tests/TestClientResource.py
@@ -10,7 +10,7 @@ class TestClientResource(unittest.TestCase):
         self.client = Client()
 
         self.test_body = {
-            "id": 9821,
+            "id": 99999,
             "name": "test client",
             "address": "Carstenallee 2",
             "city": "Herzberg",
@@ -25,7 +25,7 @@ class TestClientResource(unittest.TestCase):
         }
 
         self.ToPut = {
-            "id": 9821,
+            "id": 99999,
             "name": "test client",
             "address": "Wijnhaven 107",
             "city": "Rotterdam",
@@ -56,26 +56,26 @@ class TestClientResource(unittest.TestCase):
         body = response.json()
 
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(check_id_exists(body, 9821))
+        self.assertTrue(check_id_exists(body, 99999))
 
     def test_3_get_client(self):
-        response = self.client.get(f"{self.baseUrl}/9821")
+        response = self.client.get(f"{self.baseUrl}/99999")
         body = response.json()
 
         self.assertEqual(response.status_code, 200)
         # check of body klopt
-        self.assertEqual(body.get("id"), 9821)
+        self.assertEqual(body.get("id"), 99999)
         self.assertEqual(body.get("name"), "test client")
         self.assertEqual(body.get("address"), "Carstenallee 2")
         self.assertEqual(body.get("city"), "Herzberg")
 
     def test_4_put_client(self):
         response = self.client.put(
-            f"{self.baseUrl}/9821", json=self.ToPut)
+            f"{self.baseUrl}/99999", json=self.ToPut)
 
         self.assertEqual(response.status_code, 200)
 
-        response = self.client.get(f"{self.baseUrl}/9821")
+        response = self.client.get(f"{self.baseUrl}/99999")
         body = response.json()
 
         self.assertEqual(body.get('address'), 'Wijnhaven 107')
@@ -84,13 +84,13 @@ class TestClientResource(unittest.TestCase):
 
     def test_5_delete_client(self):
         # teardown/cleanup
-        response = self.client.delete(f"{self.baseUrl}/9821")
+        response = self.client.delete(f"{self.baseUrl}/99999")
 
         self.assertEqual(response.status_code, 200)
 
         na_delete = self.client.get(self.baseUrl)
         # check of deleted
-        self.assertFalse(check_id_exists(na_delete.json(), 9821))
+        self.assertFalse(check_id_exists(na_delete.json(), 99999))
 
     # alle orders met ship_to en bill_to 1 (de juiste client)
     # afhankelijk per endpoint of deze optie bestaat, zie endpoint documentatie

--- a/tests/TestShipmentResource.py
+++ b/tests/TestShipmentResource.py
@@ -10,7 +10,7 @@ class TestShipmentResource(unittest.TestCase):
         self.client = Client()
 
         self.test_body = {
-            "id": 10103,
+            "id": 99999,
             "order_id": 6488,
             "source_id": 36,
             "order_date": "2007-08-08",
@@ -89,7 +89,7 @@ class TestShipmentResource(unittest.TestCase):
         }
 
         self.ToPut = {
-            "id": 10103,
+            "id": 99999,
             "order_id": 6488,
             "source_id": 36,
             "order_date": "2007-08-08",
@@ -184,10 +184,10 @@ class TestShipmentResource(unittest.TestCase):
         body = response.json()
 
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(check_id_exists(body, 10103))
+        self.assertTrue(check_id_exists(body, 99999))
 
     def test_3_get_shipment(self):
-        response = self.client.get(f"{self.baseUrl}/10103")
+        response = self.client.get(f"{self.baseUrl}/99999")
         body = response.json()
 
         self.assertEqual(response.status_code, 200)
@@ -201,11 +201,11 @@ class TestShipmentResource(unittest.TestCase):
 
     def test_4_put_shipment(self):
         response = self.client.put(
-            f"{self.baseUrl}/10103", json=self.ToPut)
+            f"{self.baseUrl}/99999", json=self.ToPut)
 
         self.assertEqual(response.status_code, 200)
 
-        response = self.client.get(f"{self.baseUrl}/10103")
+        response = self.client.get(f"{self.baseUrl}/99999")
         body = response.json()
 
         self.assertEqual(body.get("id"), self.ToPut["id"])
@@ -215,7 +215,7 @@ class TestShipmentResource(unittest.TestCase):
 
     def test_5_get_shipment_items(self):
         # krijgt een lijst met item_ids en amounts terug (2 Kvps)
-        response = self.client.get(f"{self.baseUrl}/10103/items")
+        response = self.client.get(f"{self.baseUrl}/99999/items")
         body = response.json()
 
         self.assertEqual(response.status_code, 200)
@@ -230,13 +230,13 @@ class TestShipmentResource(unittest.TestCase):
 
     def test_6_delete_shipment(self):
         # teardown/cleanup
-        response = self.client.delete(f"{self.baseUrl}/10103")
+        response = self.client.delete(f"{self.baseUrl}/99999")
 
         self.assertEqual(response.status_code, 200)
 
         na_delete = self.client.get(self.baseUrl)
         # check of deleted
-        self.assertFalse(check_id_exists(na_delete.json(), 10103))
+        self.assertFalse(check_id_exists(na_delete.json(), 99999))
 
     def test_7_get_shipment_orders(self):
         # krijgt een lijst met order_ids terug die deze shipment id hebben

--- a/tests/TestWarehouseResource.py
+++ b/tests/TestWarehouseResource.py
@@ -10,7 +10,7 @@ class TestWarehouseResource(unittest.TestCase):
         self.client = Client()
 
         self.test_body = {
-            "id": 59,
+            "id": 99999,
             "code": "TESTWARE",
             "name": "test warehouse",
             "address": "Gabriele-Junken-Ring 5/1",
@@ -28,7 +28,7 @@ class TestWarehouseResource(unittest.TestCase):
         }
 
         self.ToPut = {
-            "id": 59,
+            "id": 99999,
             "code": "TESTWARE",
             "name": "test warehouse",
             "address": "Wijnhaven 107",
@@ -62,26 +62,26 @@ class TestWarehouseResource(unittest.TestCase):
         body = response.json()
 
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(check_id_exists(body, 59))
+        self.assertTrue(check_id_exists(body, 99999))
 
     def test_3_get_warehouse(self):
-        response = self.client.get(f"{self.baseUrl}/59")
+        response = self.client.get(f"{self.baseUrl}/99999")
         body = response.json()
 
         self.assertEqual(response.status_code, 200)
         # check of body klopt
-        self.assertEqual(body.get("id"), 59)
+        self.assertEqual(body.get("id"), 99999)
         self.assertEqual(body.get("code"), "TESTWARE")
         self.assertEqual(body.get("name"), "test warehouse")
         self.assertEqual(body.get("city"), "testcity")
 
     def test_4_put_warehouse(self):
         response = self.client.put(
-            f"{self.baseUrl}/59", json=self.ToPut)
+            f"{self.baseUrl}/99999", json=self.ToPut)
 
         self.assertEqual(response.status_code, 200)
 
-        response = self.client.get(f"{self.baseUrl}/59")
+        response = self.client.get(f"{self.baseUrl}/99999")
         body = response.json()
         self.assertEqual(body.get('country'), 'NL')
         self.assertEqual(body.get('province'), 'Zuid-holland')
@@ -92,13 +92,13 @@ class TestWarehouseResource(unittest.TestCase):
 
     def test_5_delete_warehouse(self):
         # teardown/cleanup
-        response = self.client.delete(f"{self.baseUrl}/59")
+        response = self.client.delete(f"{self.baseUrl}/99999")
 
         self.assertEqual(response.status_code, 200)
 
         na_delete = self.client.get(self.baseUrl)
         # check of deleted
-        self.assertFalse(check_id_exists(na_delete.json(), 59))
+        self.assertFalse(check_id_exists(na_delete.json(), 99999))
 
     # alle locations met warehouse_id 1
     # afhankelijk per endpoint of deze optie bestaat; zie endpoint documentatie


### PR DESCRIPTION
input Id's verandert naar 99999 om te voldoen aan onze teststrategie, beter voor automatische tests later
